### PR TITLE
fix: onError getting passed Error objects instead of strings

### DIFF
--- a/src/builder/entry.ts
+++ b/src/builder/entry.ts
@@ -52,6 +52,10 @@ export function importLines(referencedGlobals: string[]): string {
     // whether or not the source ever spells `React`.
     if (name === "React") continue;
 
+    // Not a real export of any package -- callers are expected to strip
+    // <EditableText> back to plain JSX before reaching here.
+    if (name === "EditableText") continue;
+
     if (name in baseScope) {
       add(
         name === "Helmet" || name === "HelmetProvider"

--- a/src/builder/standalone.ts
+++ b/src/builder/standalone.ts
@@ -239,12 +239,11 @@ export async function buildStandaloneSite(
   const source = await stripEditableText(code);
   const entry = await entryFor(source);
 
-  const [js, css] = await Promise.all([
+  const [js, css, markup] = await Promise.all([
     bundleEntry(entry, options),
     compileCss(source, options),
+    prerender ? prerenderMarkup(source) : Promise.resolve(""),
   ]);
-
-  const markup = prerender ? await prerenderMarkup(source) : "";
   const { head: hoisted, body } = splitHoisted(markup);
 
   const files: Record<string, string> = {};

--- a/src/coreComponents/EditReactCanvas.tsx
+++ b/src/coreComponents/EditReactCanvas.tsx
@@ -104,7 +104,7 @@ export default function EditReactCanvas({
         // if error - onError callback if exist, return
         if (error) {
             if (onError) {
-                onError(error);
+                onError(error instanceof Error ? error.message : String(error));
             }
             return
         }
@@ -157,7 +157,7 @@ export default function EditReactCanvas({
         var { transformedCode, error } = transformEditableTextToJSX(transformedCode);
         if (error) {
             if (onError) {
-                onError(error);
+                onError(error instanceof Error ? error.message : String(error));
             }
             return
         }


### PR DESCRIPTION
onError is typed as a string callback but two spots in EditReactCanvas were just passing the raw Error object through. If transformJSXTextToEditableText or transformEditableTextToJSX throw, whatever renders the error msg blows up instead of showing it. There's already a spot a few lines below that does `error instanceof Error ? error.message : String(error)` correctly, just made the other two match it.

Also fixed while I was in the builder code:

- importLines was emitting `import { EditableText } from "react"` which isnt a thing that exists, only hits if you call entryFor directly without stripping EditableText first
- prerenderMarkup was waiting on bundleEntry/compileCss to finish  before it even started even tho it doesnt need their output, now they just run together

small diff, no behavior change for the normal path. tests pass.
